### PR TITLE
Add LD_LIBRARY_PATH for shibd

### DIFF
--- a/container_files/tier-support/supervisord-shibsp.conf
+++ b/container_files/tier-support/supervisord-shibsp.conf
@@ -5,5 +5,4 @@ stderr_logfile = /tmp/logshibd
 stderr_logfile_maxbytes=0
 stdout_logfile = /tmp/logshibd
 stdout_logfile_maxbytes=0
-
-
+environment=LD_LIBRARY_PATH=/opt/shibboleth/lib64


### PR DESCRIPTION
This is in the upstream Shibboleth SP container, but this container uses
a completely distinct supervisord config.

Without this, it appears that shibd uses the system libcurl, instead of
the newer libcurl that the shib SP container includes.