### PR TITLE
Remove ineffective attempts to set LD_LIBRARY_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,10 +113,6 @@ RUN mkdir -p /opt/tier-support/originalFiles ; \
   cp /opt/tomee/conf/Catalina/localhost/grouper.xml /opt/tier-support/originalFiles 2>/dev/null ; \
   cp /opt/grouper/grouperWebapp/WEB-INF/web.xml /opt/tier-support/originalFiles 2>/dev/null
 
-# Export this variable so that shibd can find its CURL library
-RUN LD_LIBRARY_PATH="/opt/shibboleth/lib64"
-RUN export LD_LIBRARY_PATH
-
 WORKDIR /opt/grouper/grouperWebapp/WEB-INF/
 EXPOSE 80 443
 HEALTHCHECK NONE

--- a/container_files/usr-local-bin/librarySetupFilesForProcess.sh
+++ b/container_files/usr-local-bin/librarySetupFilesForProcess.sh
@@ -78,7 +78,6 @@ setupFilesForProcess_shib() {
     
     if [ "$GROUPER_RUN_SHIB_SP" = "true" ]
       then
-        export LD_LIBRARY_PATH=/opt/shibboleth/lib64:$LD_LIBRARY_PATH
         echo "grouperContainer; INFO: (librarySetupFilesForProcess.sh-setupFilesForProcess_shib) Appending supervisord-shibsp.conf to supervisord.conf"
         cat /opt/tier-support/supervisord-shibsp.conf >> /opt/tier-support/supervisord.conf
         returnCode=$?


### PR DESCRIPTION
As far as I can tell from running in a test container, neither of these
attempts to set LD_LIBRARY_PATH are effective, as the environment
variable does not show up in `/proc/$(pidof shibd)/environ` and
`/proc/$(pidof shibd)/maps` shows `/usr/lib64/libcurl*` in use, instead
of `/opt/shibboleth/lib64/libcurl*`.