### PR TITLE
Feature: Cleanup shibd LD_LIBRARY_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,10 +112,6 @@ RUN mkdir -p /opt/tier-support/originalFiles ; \
   cp /opt/tomee/conf/Catalina/localhost/grouper.xml /opt/tier-support/originalFiles 2>/dev/null ; \
   cp /opt/grouper/grouperWebapp/WEB-INF/web.xml /opt/tier-support/originalFiles 2>/dev/null
 
-# Export this variable so that shibd can find its CURL library
-RUN LD_LIBRARY_PATH="/opt/shibboleth/lib64"
-RUN export LD_LIBRARY_PATH
-
 WORKDIR /opt/grouper/grouperWebapp/WEB-INF/
 EXPOSE 80 443
 HEALTHCHECK NONE

--- a/container_files/tier-support/supervisord-shibsp.conf
+++ b/container_files/tier-support/supervisord-shibsp.conf
@@ -5,5 +5,4 @@ stderr_logfile = /tmp/logshibd
 stderr_logfile_maxbytes=0
 stdout_logfile = /tmp/logshibd
 stdout_logfile_maxbytes=0
-
-
+environment=LD_LIBRARY_PATH=/opt/shibboleth/lib64

--- a/container_files/usr-local-bin/librarySetupFilesForProcess.sh
+++ b/container_files/usr-local-bin/librarySetupFilesForProcess.sh
@@ -50,7 +50,6 @@ setupFilesForProcess_shib() {
     
     if [ "$GROUPER_RUN_SHIB_SP" = "true" ]
       then
-        export LD_LIBRARY_PATH=/opt/shibboleth/lib64:$LD_LIBRARY_PATH
         echo "grouperContainer; INFO: (librarySetupFilesForProcess.sh-setupFilesForProcess_shib) Appending supervisord-shibsp.conf to supervisord.conf"
         cat /opt/tier-support/supervisord-shibsp.conf >> /opt/tier-support/supervisord.conf
         returnCode=$?


### PR DESCRIPTION
The existing attempts to set the `LD_LIBRARY_PATH` for `shibd` were not effective; I noticed that there was some certificate activity that failed(*) and examining the memory mapping for the process in the container confirmed the older `libcurl` was still in use. Finding the points where attempts were made to set it revealed these that could not possibly work; presumably they did at one time and other things around them were changed.

Unfortunately, I am not setup to run the test suite, so I do not know what the effect there will be. I also do not know what might break using the expected version of `libcurl` or other libraries that might be in the path.

(*) I regret to say that I do not remember what was broken/unexpected, as it has been 5+ months. I either found a workaround or realized I could otherwise ignore it, though.